### PR TITLE
Allow for use of Perl v5.10.1

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ name 'Catalyst-Plugin-BigSitemap';
 abstract 'A Catalyst Plugin for Sitemaps up to 2.5 billion urls.';
 license 'perl';
 version '1.0.1';
-perl_version '5.010002';
+perl_version '5.010001';
 all_from 'lib/Catalyst/Plugin/BigSitemap.pm';
 
 requires 'Catalyst'; 


### PR DESCRIPTION
Red Hat Enterprise Linux 6 is still supported by Red Hat, but have only Perl v5.10.1, and not Perl v5.10.2 that this module requires.

I have tested this and it work with Perl v5.10.1 it better to require that then Perl v5.10.2.
